### PR TITLE
Add contrib to the updated debian repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,17 +103,17 @@ nano /etc/apt/sources.list
 #deb https://mirrors.aliyun.com/debian bookworm-backports main non-free contrib
 #deb-src https://mirrors.aliyun.com/debian bookworm-backports main non-free contrib
 
-deb http://deb.debian.org/debian bookworm main non-free-firmware
-deb-src http://deb.debian.org/debian bookworm main non-free-firmware
+deb http://deb.debian.org/debian bookworm main non-free-firmware contrib
+deb-src http://deb.debian.org/debian bookworm main non-free-firmware contrib
 
-deb http://deb.debian.org/debian-security/ bookworm-security main non-free-firmware
-deb-src http://deb.debian.org/debian-security/ bookworm-security main non-free-firmware
+deb http://deb.debian.org/debian-security/ bookworm-security main non-free-firmware contrib
+deb-src http://deb.debian.org/debian-security/ bookworm-security main non-free-firmware contrib
 
-deb http://deb.debian.org/debian bookworm-updates main non-free-firmware
-deb-src http://deb.debian.org/debian bookworm-updates main non-free-firmware
+deb http://deb.debian.org/debian bookworm-updates main non-free-firmware contrib
+deb-src http://deb.debian.org/debian bookworm-updates main non-free-firmware contrib
 
-deb http://deb.debian.org/debian bookworm-backports main non-free-firmware
-deb-src http://deb.debian.org/debian bookworm-backports main non-free-firmware
+deb http://deb.debian.org/debian bookworm-backports main non-free-firmware contrib
+deb-src http://deb.debian.org/debian bookworm-backports main non-free-firmware contrib
 ```
 
 ### Compiling linux-headers for DKMS (Dynamic Kernel Module Support)


### PR DESCRIPTION
The `zfs-dkms` and `zfsutils-linux` packages are in the contrib component of the debian repos and need to be specified when updating which repos to use. You can see that they're already there in the aliyun defaults but not in the suggested edit.